### PR TITLE
Put custom context properties under 'properties'

### DIFF
--- a/specifications/09-strategy-constraints.json
+++ b/specifications/09-strategy-constraints.json
@@ -207,7 +207,9 @@
             "description": "Feature.constraints.custom should be enabled in prod for norway",
             "context": {
                 "environment": "prod",
-                "country": "norway"
+                "properties": {
+                    "country": "norway"
+                }
             },
             "toggleName": "Feature.constraints.custom",
             "expectedResult": true
@@ -216,7 +218,9 @@
             "description": "Feature.constraints.custom should NOT be enabled in prod for denmark",
             "context": {
                 "environment": "prod",
-                "country": "denmark"
+                "properties": {
+                    "country": "denmark"
+                }
             },
             "toggleName": "Feature.constraints.custom",
             "expectedResult": false


### PR DESCRIPTION
Statically typed clients have no way of implementing custom properties
at the top level of the context object. A better solution here is to use
the 'properties' sub-property as recommended by the documentation.