### PR TITLE
docs: fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Unleash Client Specifications
 Implementing a Unleash client for a specific platfrom can be a challenge in it's own. And we want the clients to follow specific platform and language conventions, but at the same time we want the clients to adhere to the unleash contract, and give predictable results across platforms.
 
-This project tries to define the expected results of certain predefined set of feature toggles, using the  [built-in activation strategies](https://github.com/Unleash/unleash/blob/main/docs/activation-strategies.md) and with a given [unleash context](https://github.com/Unleash/unleash/blob/main/docs/unleash-context.md).
+This project tries to define the expected results of certain predefined set of feature toggles, using the  [built-in activation strategies](https://docs.getunleash.io/user_guide/activation_strategy) and with a given [unleash context](https://docs.getunleash.io/user_guide/unleash_context).
 
 
 ### Test structure
@@ -73,11 +73,11 @@ Fields description:
 - **state** - The list of toggles coming from the unleash-server. Would be the same response as the client will see when requesting `http://unleash-api/client/features`. The state will be used for all test cases in this specification.
 - **tests** - The list of `isEnabled` tests cases to run.
   - **description** - Describes what this test case is testing. Suitable to output as the error message if the test case fails.
-  - **context** - The [unleash context](https://github.com/Unleash/unleash/blob/main/docs/unleash-context.md) the client should setup.
+  - **context** - The [unleash context](https://docs.getunleash.io/user_guide/unleash_context) the client should setup.
   - **toggleName** - The toggle name to send in to the `isEnabled` call in this test case.
   - **expectedResult** - The expected result of the `isEnabled` call with the given `toggleName`.
 - **variantTests** - The list of `getVariant` tests cases to run.
   - **description** - Describes what this test case is testing. Suitable to output as the error message if the test case fails.
-  - **context** - The [unleash context](https://github.com/Unleash/unleash/blob/main/docs/unleash-context.md) the client should setup.
+  - **context** - The [unleash context](https://docs.getunleash.io/user_guide/unleash_context) the client should setup.
   - **toggleName** - The toggle name to send in to the `isEnabled` call in this test case.
   - **expectedResult** - The expected result of the `getVariant` call with the given `toggleName`.


### PR DESCRIPTION
## About the changes
This is a minor change updating some broken links in the readme file. I've chosen linking to the official documentation rather than the Unleash GitHub repository, but let me know if you prefer otherwise.