### PR TITLE
fix: make tests actually fail when validation of schema fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ testCases.forEach(name => {
 
     if (error) {
         console.error(`${name} ${chalk.red('is not valid')}. \n`, error);
+        process.exitCode(1);
     } else {
         console.log(`${name} ${chalk.green('is valid')}`);
     }


### PR DESCRIPTION
The validation tests don't actually fail correctly when validation picks up and error. This sets the exit code to a non zero value so that tests will actually fail