### PR TITLE
fix: add cases for missing contextFields together with IN

### DIFF
--- a/schema/context-schema.js
+++ b/schema/context-schema.js
@@ -7,7 +7,7 @@ const schema = Joi.object().keys({
     currentTime: Joi.string().optional(),
     environment: Joi.string().optional(),
     appName: Joi.string(),
-    properties: Joi.object().pattern(/\w+/, Joi.string()),
+    properties: Joi.object().pattern(/\w+/, Joi.string().allow(null)),
 })
 
 module.exports = schema;

--- a/specifications/13-constraint-operators.json
+++ b/specifications/13-constraint-operators.json
@@ -366,6 +366,42 @@
                         ]
                     }
                 ]
+            },
+            {
+                "name": "F8.missing-field.IN",
+                "description": "missing field",
+                "enabled": true,
+                "strategies": [
+                    {
+                        "name": "default",
+                        "parameters": {},
+                        "constraints": [
+                            {
+                                "contextName": "customFieldMissing",
+                                "operator": "IN",
+                                "values": ["s1"]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "F8.missing-field.NOT_IN",
+                "description": "missing field",
+                "enabled": true,
+                "strategies": [
+                    {
+                        "name": "default",
+                        "parameters": {},
+                        "constraints": [
+                            {
+                                "contextName": "customFieldMissing",
+                                "operator": "NOT_IN",
+                                "values": ["s1"]
+                            }
+                        ]
+                    }
+                ]
             }
 
         ]
@@ -734,6 +770,38 @@
             },
             "toggleName":  "F7.invalid-operator",
             "expectedResult": false
+        },
+        {
+            "description": "F8.missing-field.IN should return false",
+            "context": {},
+            "toggleName":  "F8.missing-field.IN",
+            "expectedResult": false
+        },
+        {
+            "description": "F8.missing-field.IN should return true when present",
+            "context": {
+                "properties": {
+                    "customFieldMissing": "s1"
+                }
+            },
+            "toggleName":  "F8.missing-field.IN",
+            "expectedResult": true
+        },
+        {
+            "description": "F8.missing-field.NOT_IN should return true",
+            "context": {},
+            "toggleName":  "F8.missing-field.NOT_IN",
+            "expectedResult": true
+        },
+        {
+            "description": "F8.missing-field.NOT_IN should return true when null",
+            "context": {
+                "properties": {
+                    "customFieldMissing": null
+                }
+            },
+            "toggleName":  "F8.missing-field.NOT_IN",
+            "expectedResult": true
         }
     ]
 }


### PR DESCRIPTION
We saw some inconsistent handling of missing context fields on in the SDK together with `IN` and `NOT_IN` operator. 

E.g. When the user has a `NOT_IN` and does not provide any context field the SDK should return true, while the node SDK is currently always returning false in that case (fixed via https://github.com/Unleash/unleash-client-node/pull/340)
