### PR TITLE
fix: set segment id to 404

### DIFF
--- a/specifications/15-global-constraints.json
+++ b/specifications/15-global-constraints.json
@@ -61,7 +61,7 @@
                 "value": "1.2.2"
               }
             ],
-            "segments": [3]
+            "segments": [404]
           }
         ]
       },


### PR DESCRIPTION
This PR fixes a broken specification test where the segment was supposed to be missing, but in reality it was defined, resulting in a broken test.