### PR TITLE
If variants are empty we expect FT to be disabled

### DIFF
--- a/specifications/08-variants.json
+++ b/specifications/08-variants.json
@@ -168,6 +168,18 @@
                         }
                     }
                 ]
+            },
+            {
+                "name": "Feature.Variants.F",
+                "description": "Empty variants",
+                "enabled": true,
+                "strategies": [
+                    {
+                        "name": "default",
+                        "parameters": {}
+                    }
+                ],
+                "variants": []
             }
         ]
     },
@@ -367,6 +379,17 @@
                 "userId": "0"
             },
             "toggleName": "Feature.Variants.E",
+            "expectedResult": {
+                "name": "disabled",
+                "enabled": false
+            }
+        },
+        {
+            "description": "Feature.Variants.F should be disabled when variants are empty",
+            "context": {
+                "userId": "0"
+            },
+            "toggleName": "Feature.Variants.F",
             "expectedResult": {
                 "name": "disabled",
                 "enabled": false


### PR DESCRIPTION
## About the changes
When variants are empty, even if the feature toggle is enabled we expect the SDK to respond with the default variant (which unless overridden should be false)

Examples of the behavior can be found in:
- Node SDK: https://github.com/Unleash/unleash-client-node/blob/c031cd70279ede90ead1839fdc8537eca9187713/src/client.ts#L157-L164 
- Go SDK: https://github.com/Unleash/unleash-client-go/blob/ebfcf13a52ddbfcb6c4fe96afb4b713acad25739/client.go#L368-L370  and [default variant disabled](https://github.com/Unleash/unleash-client-go/blob/3c2306073d115829dc8943877f109c48da689169/api/variant.go#L78-L80)
- Java SDK test: https://github.com/Unleash/unleash-client-java/blob/be22d603ae9a37cb0617e6ac3397e823c244f9fa/src/test/java/io/getunleash/variant/VariantUtilTest.java#L41-L49 
- Python SDK test: https://github.com/Unleash/unleash-client-python/blob/d37ec32a436f62cc1e12c329418c225ce1a65c68/tests/unit_tests/test_variants.py#L93-L97


