### PR TITLE
fix: this patches the strEndsWith test case

### DIFF
--- a/specifications/13-constraint-operators.json
+++ b/specifications/13-constraint-operators.json
@@ -53,7 +53,7 @@
                             {
                                 "contextName": "email",
                                 "operator": "STR_ENDS_WITH",
-                                "values": ["@some-email.com"]
+                                "values": ["some-email.com"]
                             }
                         ]
                     }
@@ -71,7 +71,7 @@
                             {
                                 "contextName": "email",
                                 "operator": "STR_ENDS_WITH",
-                                "values": ["@some-email.com"],
+                                "values": ["some-email.com"],
                                 "caseInsensitive": true
                             }
                         ]

--- a/specifications/13-constraint-operators.json
+++ b/specifications/13-constraint-operators.json
@@ -451,7 +451,7 @@
             "description": "F3.endsWith should be enabled",
             "context": {
                 "properties": {
-                    "email": "@some-email.com"
+                    "email": "test@some-email.com"
                 }
             },
             "toggleName": "F3.endsWith",
@@ -461,7 +461,7 @@
             "description": "F3.endsWith should be disabled when casing is incorrect",
             "context": {
                 "properties": {
-                    "email": "@some-EMAIL.com"
+                    "email": "test@some-EMAIL.com"
                 }
             },
             "toggleName": "F3.endsWith",
@@ -471,7 +471,7 @@
             "description": "F3.endsWith.ignoringCase should be enabled",
             "context": {
                 "properties": {
-                    "email": "@SOME-EMAIL.com"
+                    "email": "test@SOME-EMAIL.com"
                 }
             },
             "toggleName": "F3.endsWith.ignoringCase",
@@ -481,7 +481,7 @@
             "description": "F3.endsWith should be disabled",
             "context": {
                 "properties": {
-                    "email": "@another-email.com"
+                    "email": "test@another-email.com"
                 }
             },
             "toggleName": "F3.endsWith",
@@ -491,7 +491,7 @@
             "description": "F4.contains should be enabled",
             "context": {
                 "properties": {
-                    "email": "@some-email.com"
+                    "email": "test@some-email.com"
                 }
             },
             "toggleName": "F4.contains",
@@ -501,7 +501,7 @@
             "description": "F4.contains should be disabled",
             "context": {
                 "properties": {
-                    "email": "@another.com"
+                    "email": "test@another.com"
                 }
             },
             "toggleName": "F4.contains",
@@ -511,7 +511,7 @@
             "description": "F4.contains.inverted should be enabled",
             "context": {
                 "properties": {
-                    "email": "@another.com"
+                    "email": "test@another.com"
                 }
             },
             "toggleName": "F4.contains.inverted",


### PR DESCRIPTION
The strEndsWith test case was previously checking that @some-email.com ends with @some-email.com. This means that an incorrectly implemented SDK could check that the context property ended with the constraint property and still pass the specifications. 

This patches that behaviour, meaning that dependent SDKs will now fail that test case correctly if the implementation is incorrect.