### PR TITLE
fix: updates variant weights to sum to 1000

### DIFF
--- a/specifications/08-variants.json
+++ b/specifications/08-variants.json
@@ -16,7 +16,7 @@
                 "variants": [
                     {
                         "name": "variant1",
-                        "weight": 1,
+                        "weight": 10,
                         "payload": {
                             "type": "string",
                             "value": "val1"
@@ -32,7 +32,7 @@
                 "variants": [
                     {
                         "name": "variant1",
-                        "weight": 1,
+                        "weight": 10,
                         "payload": {
                             "type": "string",
                             "value": "val1"
@@ -40,7 +40,7 @@
                     },
                     {
                         "name": "variant2",
-                        "weight": 1,
+                        "weight": 10,
                         "payload": {
                             "type": "string",
                             "value": "val2"
@@ -56,7 +56,7 @@
                 "variants": [
                     {
                         "name": "variant1",
-                        "weight": 33,
+                        "weight": 333,
                         "payload": {
                             "type": "string",
                             "value": "val1"
@@ -64,7 +64,7 @@
                     },
                     {
                         "name": "variant2",
-                        "weight": 33,
+                        "weight": 333,
                         "payload": {
                             "type": "string",
                             "value": "val2"
@@ -72,7 +72,7 @@
                     },
                     {
                         "name": "variant3",
-                        "weight": 33,
+                        "weight": 334,
                         "payload": {
                             "type": "string",
                             "value": "val3"
@@ -88,7 +88,7 @@
                 "variants": [
                     {
                         "name": "variant1",
-                        "weight": 1,
+                        "weight": 10,
                         "payload": {
                             "type": "string",
                             "value": "val1"
@@ -96,7 +96,7 @@
                     },
                     {
                         "name": "variant2",
-                        "weight": 49,
+                        "weight": 490,
                         "payload": {
                             "type": "string",
                             "value": "val2"
@@ -104,7 +104,7 @@
                     },
                     {
                         "name": "variant3",
-                        "weight": 50,
+                        "weight": 500,
                         "payload": {
                             "type": "string",
                             "value": "val3"
@@ -120,7 +120,7 @@
                 "variants": [
                     {
                         "name": "variant1",
-                        "weight": 33,
+                        "weight": 333,
                         "payload": {
                             "type": "string",
                             "value": "val1"
@@ -132,7 +132,7 @@
                     },
                     {
                         "name": "variant2",
-                        "weight": 33,
+                        "weight": 333,
                         "payload": {
                             "type": "string",
                             "value": "val2"
@@ -140,7 +140,7 @@
                     },
                     {
                         "name": "variant3",
-                        "weight": 34,
+                        "weight": 334,
                         "payload": {
                             "type": "string",
                             "value": "val3"

--- a/specifications/12-custom-stickiness.json
+++ b/specifications/12-custom-stickiness.json
@@ -21,7 +21,7 @@
                 "variants": [
                     {
                         "name": "blue",
-                        "weight": 25,
+                        "weight": 250,
                         "stickiness": "customField",
                         "payload": {
                             "type": "string",
@@ -30,7 +30,7 @@
                     },
                     {
                         "name": "red",
-                        "weight": 25,
+                        "weight": 250,
                         "stickiness": "customField",
                         "payload": {
                             "type": "string",
@@ -39,7 +39,7 @@
                     },
                     {
                         "name": "green",
-                        "weight": 25,
+                        "weight": 250,
                         "stickiness": "customField",
                         "payload": {
                             "type": "string",
@@ -48,7 +48,7 @@
                     },
                     {
                         "name": "yellow",
-                        "weight": 25,
+                        "weight": 250,
                         "stickiness": "customField",
                         "payload": {
                             "type": "string",


### PR DESCRIPTION
## What

This updates the variant weights to sum to 1000 in cases where it makes sense. 

## Why

This is to handle a change in the Unleash server where variant weights can be non integer values. This allows the users to set more fine grained control of the variant weights, however this means the Unleash server treats the variant weights as summing to 1000 rather than 100. This can be a breaking change to SDKs in languages that have sized data types where the variant weight was defined as a maximum of a single byte

## Considerations

- This affects the Rust SDK, which currently doesn't support bleeding edge of the client spec, we should back port this to a tagged version of the spec that the Rust SDK does support

- Need to test this version against all of our SDKs before we merge this