### PR TITLE
fix: trim duplicate variant strategy property

### DIFF
--- a/specifications/16-strategy-variants.json
+++ b/specifications/16-strategy-variants.json
@@ -139,7 +139,6 @@
         "name": "Feature.strategy.variant.fallback",
         "description": "Strategy variants fall back to feature variants",
         "enabled": true,
-        "variants": [],
         "strategies": [
           {
             "name": "flexibleRollout",


### PR DESCRIPTION
Seems we have a duplicate property variants property in the variant strategy tests, this removes that