### PR TITLE
feat: add empty variant test when strategy does not match/feature is disabled

### DIFF
--- a/specifications/08-variants.json
+++ b/specifications/08-variants.json
@@ -421,7 +421,7 @@
             }
         },
         {
-            "description": "Feature.Variants.G should be disabled when gradual rollout is 0%, but has variants",
+            "description": "Feature.Variants.G should be disabled when feature is calculated as false, but has variants",
             "context": {
                 "userId": "0"
             },

--- a/specifications/08-variants.json
+++ b/specifications/08-variants.json
@@ -180,6 +180,31 @@
                     }
                 ],
                 "variants": []
+            },
+            {
+                "name": "Feature.Variants.G",
+                "description": "0% gradual rollout, but has variants",
+                "enabled": true,
+                "strategies": [
+                    {
+                        "name": "flexibleRollout",
+                        "parameters": {
+                            "rollout": "0",
+                            "stickiness": "default",
+                            "groupId": "feature-variant-g"
+                        }
+                    }
+                ],
+                "variants": [
+                    {
+                        "name": "variant1",
+                        "weight": 1,
+                        "payload": {
+                            "type": "string",
+                            "value": "val1"
+                        }
+                    }
+                ]
             }
         ]
     },
@@ -390,6 +415,17 @@
                 "userId": "0"
             },
             "toggleName": "Feature.Variants.F",
+            "expectedResult": {
+                "name": "disabled",
+                "enabled": false
+            }
+        },
+        {
+            "description": "Feature.Variants.G should be disabled when gradual rollout is 0%, but has variants",
+            "context": {
+                "userId": "0"
+            },
+            "toggleName": "Feature.Variants.G",
             "expectedResult": {
                 "name": "disabled",
                 "enabled": false


### PR DESCRIPTION
SDKs should provide a disabled variant when the rollout percentage is set to 0%. This adjustment is being implemented to address an issue with the PHP SDK. Currently, the PHP SDK returns a variant even when a feature is disabled by a strategy.