### PR TITLE
fix: adds a test case for when strategy variants are empty but base variants are present

### DIFF
--- a/specifications/16-strategy-variants.json
+++ b/specifications/16-strategy-variants.json
@@ -29,9 +29,7 @@
               {
                 "contextName": "environment",
                 "operator": "IN",
-                "values": [
-                  "dev"
-                ]
+                "values": ["dev"]
               }
             ]
           }
@@ -64,9 +62,7 @@
               {
                 "contextName": "environment",
                 "operator": "IN",
-                "values": [
-                  "dev"
-                ]
+                "values": ["dev"]
               }
             ]
           }
@@ -194,6 +190,33 @@
           }
         ],
         "variants": []
+      },
+      {
+        "name": "Feature.strategy.no.strategy.variants",
+        "description": "Toggle with no strategy variants",
+        "enabled": true,
+        "strategies": [
+          {
+            "name": "flexibleRollout",
+            "parameters": {
+              "rollout": "100",
+              "stickiness": "default",
+              "groupId": "a"
+            },
+            "variants": [],
+            "constraints": []
+          }
+        ],
+        "variants": [
+          {
+            "name": "variantNameA",
+            "weight": 1,
+            "payload": {
+              "type": "number",
+              "value": "1"
+            }
+          }
+        ]
       }
     ]
   },
@@ -299,6 +322,22 @@
       "toggleName": "Feature.strategy.numeric.variants",
       "expectedResult": {
         "name": "variantNameB",
+        "payload": {
+          "type": "number",
+          "value": "1"
+        },
+        "enabled": true
+      }
+    },
+    {
+      "description": "Feature.strategy.no.strategy.variants should fall back to base variants",
+      "context": {
+        "userId": "0"
+      },
+      "toggleName": "Feature.strategy.no.strategy.variants",
+      "expectedResult": {
+        "name": "variantNameA",
+        "weight": 1,
         "payload": {
           "type": "number",
           "value": "1"


### PR DESCRIPTION
This adds a test case for strategy variants to check that the returned value is correct when strategy variants are defined as an empty list (the default that Unleash sends) but base variants are present on the toggle