### PR TITLE
fix: add test case for dependency asking for disabled variant

### DIFF
--- a/specifications/17-dependent-features.json
+++ b/specifications/17-dependent-features.json
@@ -614,7 +614,7 @@
         "description": "The parent is disabled. The child expects the parent's variant to be \"disabled\".",
         "enabled": true,
         "dependencies": [{
-          "feature": "parent.disabled"
+          "feature": "parent.disabled",
           "variants": ["disabled"]
         }],
         "strategies": [{

--- a/specifications/17-dependent-features.json
+++ b/specifications/17-dependent-features.json
@@ -608,6 +608,24 @@
             }
           ]
         }]
+      },
+      {
+        "name": "parent.disabled.child.expects.disabled.variant",
+        "description": "The parent is disabled. The child expects the parent's variant to be \"disabled\".",
+        "enabled": true,
+        "dependencies": [{
+          "feature": "parent.disabled"
+          "variants": ["disabled"]
+        }],
+        "strategies": [{
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "groupId"
+          },
+          "variants": []
+        }]
       }
     ]
   },
@@ -723,9 +741,14 @@
       "context": {},
       "toggleName": "parent.default.variant.child.enabled",
       "expectedResult": true
+    },
+    {
+      "description": "Child is disabled if the parent is disabled, even if the child's expected variant is the disabled variant",
+      "context": {},
+      "toggleName": "parent.disabled.child.expects.disabled.variant",
+      "expectedResult": false
     }
-  ]
-,
+  ],
   "variantTests": [
     {
       "description": "Child yields its variant when both parent and child are enabled.",
@@ -927,8 +950,3 @@
     }
   ]
 }
-
-
-
-
-


### PR DESCRIPTION
This change adds a new test case to the dependent features spec:
If a child depends on a parent's variant, but expects that variant to
be "disabled", the child should nonetheless be disabled if the parent
is disabled.

In other words, the only way for that to be true is if the parent has
a named variant called "disabled".

This covers a hole in the spec where a child could be enabled even if
its parent was disabled, as long as the child depended on the parent's
"disabled" variant.