### PR TITLE
feat: add `feature_enabled` property to variants

### DIFF
--- a/schema/test-case-schema.js
+++ b/schema/test-case-schema.js
@@ -24,7 +24,8 @@ const schema = Joi.object().keys({
                     type: Joi.string().required(),
                     value: Joi.string().required().allow(""),
                 }).optional(),
-                enabled: Joi.boolean().required()
+                enabled: Joi.boolean().required(),
+                feature_enabled: Joi.boolean().required()
             }),
         })
     )

--- a/specifications/08-variants.json
+++ b/specifications/08-variants.json
@@ -242,7 +242,8 @@
                     "type": "string",
                     "value": "val1"
                 },
-                "enabled": true
+                "enabled": true,
+                "feature_enabled": true
             }
         },
         {
@@ -251,7 +252,8 @@
             "toggleName": "Feature.Variants.MissingToggle",
             "expectedResult": {
                 "name": "disabled",
-                "enabled": false
+                "enabled": false,
+                "feature_enabled": false
             }
         },
         {
@@ -266,7 +268,8 @@
                     "type": "string",
                     "value": "val2"
                 },
-                "enabled": true
+                "enabled": true,
+                "feature_enabled": true
             }
         },
         {
@@ -281,7 +284,8 @@
                     "type": "string",
                     "value": "val1"
                 },
-                "enabled": true
+                "enabled": true,
+                "feature_enabled": true
             }
         },
         {
@@ -296,7 +300,8 @@
                     "type": "string",
                     "value": "val1"
                 },
-                "enabled": true
+                "enabled": true,
+                "feature_enabled": true
             }
         },
         {
@@ -311,7 +316,8 @@
                     "type": "string",
                     "value": "val2"
                 },
-                "enabled": true
+                "enabled": true,
+                "feature_enabled": true
             }
         },
         {
@@ -326,7 +332,8 @@
                     "type": "string",
                     "value": "val3"
                 },
-                "enabled": true
+                "enabled": true,
+                "feature_enabled": true
             }
         },
         {
@@ -341,7 +348,8 @@
                     "type": "string",
                     "value": "val1"
                 },
-                "enabled": true
+                "enabled": true,
+                "feature_enabled": true
             }
         },
         {
@@ -356,7 +364,8 @@
                     "type": "string",
                     "value": "val2"
                 },
-                "enabled": true
+                "enabled": true,
+                "feature_enabled": true
             }
         },
         {
@@ -371,7 +380,8 @@
                     "type": "string",
                     "value": "val3"
                 },
-                "enabled": true
+                "enabled": true,
+                "feature_enabled": true
             }
         },
         {
@@ -386,7 +396,8 @@
                     "type": "string",
                     "value": "val1"
                 },
-                "enabled": true
+                "enabled": true,
+                "feature_enabled": true
             }
         },
         {
@@ -401,7 +412,8 @@
                     "type": "string",
                     "value": "val1"
                 },
-                "enabled": true
+                "enabled": true,
+                "feature_enabled": true
             }
         },
         {
@@ -416,7 +428,8 @@
                     "type": "string",
                     "value": "val2"
                 },
-                "enabled": true
+                "enabled": true,
+                "feature_enabled": true
             }
         },
         {
@@ -427,7 +440,8 @@
             "toggleName": "Feature.Variants.E",
             "expectedResult": {
                 "name": "disabled",
-                "enabled": false
+                "enabled": false,
+                "feature_enabled": false
             }
         },
         {
@@ -438,7 +452,8 @@
             "toggleName": "Feature.Variants.F",
             "expectedResult": {
                 "name": "disabled",
-                "enabled": false
+                "enabled": false,
+                "feature_enabled": true
             }
         },
         {
@@ -449,7 +464,8 @@
             "toggleName": "Feature.Variants.G",
             "expectedResult": {
                 "name": "disabled",
-                "enabled": false
+                "enabled": false,
+                "feature_enabled": false
             }
         },
         {
@@ -464,7 +480,8 @@
                     "type": "number",
                     "value": "1.2"
                 },
-                "enabled": true
+                "enabled": true,
+                "feature_enabled": true
             }
         }
     ]

--- a/specifications/12-custom-stickiness.json
+++ b/specifications/12-custom-stickiness.json
@@ -126,7 +126,8 @@
                     "type": "string",
                     "value": "val1"
                 },
-                "enabled": true
+                "enabled": true,
+                "feature_enabled": true
             }
         },
         {
@@ -141,7 +142,8 @@
                     "type": "string",
                     "value": "val1"
                 },
-                "enabled": true
+                "enabled": true,
+                "feature_enabled": true
             }
         },
         {
@@ -156,7 +158,8 @@
                     "type": "string",
                     "value": "val1"
                 },
-                "enabled": true
+                "enabled": true,
+                "feature_enabled": true
             }
         },
         {
@@ -171,7 +174,8 @@
                     "type": "string",
                     "value": "val1"
                 },
-                "enabled": true
+                "enabled": true,
+                "feature_enabled": true
             }
         }
     ]

--- a/specifications/16-strategy-variants.json
+++ b/specifications/16-strategy-variants.json
@@ -233,7 +233,8 @@
           "type": "string",
           "value": "variantValue"
         },
-        "enabled": true
+        "enabled": true,
+        "feature_enabled": true
       }
     },
     {
@@ -244,7 +245,8 @@
       "toggleName": "Feature.strategy.variant.with.constraint",
       "expectedResult": {
         "name": "disabled",
-        "enabled": false
+        "enabled": false,
+        "feature_enabled": false
       }
     },
     {
@@ -259,7 +261,8 @@
           "type": "string",
           "value": "variantValue"
         },
-        "enabled": true
+        "enabled": true,
+        "feature_enabled": true
       }
     },
     {
@@ -274,7 +277,8 @@
           "type": "string",
           "value": "variantValueA"
         },
-        "enabled": true
+        "enabled": true,
+        "feature_enabled": true
       }
     },
     {
@@ -289,7 +293,8 @@
           "type": "string",
           "value": "variantValueB"
         },
-        "enabled": true
+        "enabled": true,
+        "feature_enabled": true
       }
     },
     {
@@ -298,7 +303,8 @@
       "toggleName": "Feature.strategy.empty.variants",
       "expectedResult": {
         "name": "disabled",
-        "enabled": false
+        "enabled": false,
+        "feature_enabled": true
       }
     },
     {
@@ -311,7 +317,8 @@
           "type": "string",
           "value": "fallbackValue"
         },
-        "enabled": true
+        "enabled": true,
+        "feature_enabled": true
       }
     },
     {
@@ -326,7 +333,8 @@
           "type": "number",
           "value": "1"
         },
-        "enabled": true
+        "enabled": true,
+        "feature_enabled": true
       }
     },
     {
@@ -341,7 +349,8 @@
           "type": "number",
           "value": "1"
         },
-        "enabled": true
+        "enabled": true,
+        "feature_enabled": true
       }
     }
   ]

--- a/specifications/17-dependent-features.json
+++ b/specifications/17-dependent-features.json
@@ -760,7 +760,8 @@
           "type": "string",
           "value": "variantValue"
         },
-        "enabled": true
+        "enabled": true,
+        "feature_enabled": true
       }
     },
     {
@@ -769,7 +770,8 @@
       "toggleName": "parent.enabled.child.disabled",
       "expectedResult": {
         "name": "disabled",
-        "enabled": false
+        "enabled": false,
+        "feature_enabled": false
       }
     },
     {
@@ -778,7 +780,8 @@
       "toggleName": "parent.disabled.child.enabled",
       "expectedResult": {
         "name": "disabled",
-        "enabled": false
+        "enabled": false,
+        "feature_enabled": false
       }
     },
     {
@@ -787,7 +790,8 @@
       "toggleName": "parent.disabled.child.disabled",
       "expectedResult": {
         "name": "disabled",
-        "enabled": false
+        "enabled": false,
+        "feature_enabled": false
       }
     },
     {
@@ -800,7 +804,8 @@
           "type": "string",
           "value": "variantValue"
         },
-        "enabled": true
+        "enabled": true,
+        "feature_enabled": true
       }
     },
     {
@@ -809,7 +814,8 @@
       "toggleName": "parent.disabled.not.satisfied.child.enabled",
       "expectedResult": {
         "name": "disabled",
-        "enabled": false
+        "enabled": false,
+        "feature_enabled": false
       }
     },
     {
@@ -822,7 +828,8 @@
           "type": "string",
           "value": "variantValue"
         },
-        "enabled": true
+        "enabled": true,
+        "feature_enabled": true
       }
     },
     {
@@ -835,7 +842,8 @@
           "type": "string",
           "value": "variantValue"
         },
-        "enabled": true
+        "enabled": true,
+        "feature_enabled": true
       }
     },
     {
@@ -848,7 +856,8 @@
           "type": "string",
           "value": "variantValue"
         },
-        "enabled": true
+        "enabled": true,
+        "feature_enabled": true
       }
     },
     {
@@ -857,7 +866,8 @@
       "toggleName": "parent.non.matching.variant.child.enabled",
       "expectedResult": {
         "name": "disabled",
-        "enabled": false
+        "enabled": false,
+        "feature_enabled": false
       }
     },
     {
@@ -870,7 +880,8 @@
           "type": "string",
           "value": "variantValue"
         },
-        "enabled": true
+        "enabled": true,
+        "feature_enabled": true
       }
     },
     {
@@ -879,7 +890,8 @@
       "toggleName": "multiple.parents.not.satisfied.child.enabled",
       "expectedResult": {
         "name": "disabled",
-        "enabled": false
+        "enabled": false,
+        "feature_enabled": false
       }
     },
     {
@@ -888,7 +900,8 @@
       "toggleName": "parents.not.exist.child.enabled",
       "expectedResult": {
         "name": "disabled",
-        "enabled": false
+        "enabled": false,
+        "feature_enabled": false
       }
     },
     {
@@ -897,7 +910,8 @@
       "toggleName": "child.with.cycle",
       "expectedResult": {
         "name": "disabled",
-        "enabled": false
+        "enabled": false,
+        "feature_enabled": false
       }
     },
     {
@@ -906,7 +920,8 @@
       "toggleName": "child.with.transitive.dependency",
       "expectedResult": {
         "name": "disabled",
-        "enabled": false
+        "enabled": false,
+        "feature_enabled": false
       }
     },
     {
@@ -921,7 +936,8 @@
           "type": "string",
           "value": "variantValue"
         },
-        "enabled": true
+        "enabled": true,
+        "feature_enabled": true
       }
     },
     {
@@ -932,7 +948,8 @@
       "toggleName": "child.with.non.matching.constraint",
       "expectedResult": {
         "name": "disabled",
-        "enabled": false
+        "enabled": false,
+        "feature_enabled": false
       }
     },
     {
@@ -945,7 +962,8 @@
           "type": "string",
           "value": "variantValue"
         },
-        "enabled": true
+        "enabled": true,
+        "feature_enabled": true
       }
     }
   ]


### PR DESCRIPTION
## About the changes
Added `feature_enabled` property in Variant to indicate feature toggle status independent of variant presence.

Related to https://github.com/Unleash/unleash-client-python/issues/284

Internal ticket: [issue/SR-151/update-client-spec-to-include-feature-enabled-property-in-variant](https://linear.app/unleash/issue/SR-151/update-client-spec-to-include-feature-enabled-property-in-variant)

### Use case:
Before this change, clients had to check if variants existed for a specific feature or use a combination of get_variant() and is_enabled() calls, which could lead to inaccurate metrics. This change allows for a single method call that provides complete information about the feature's enablement and associated variant.

