### PR TITLE
test: add missing test for custom stickiness only on strategy with variants

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/client-specification",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "description": "A collection of test specifications to guide client implementations in various languages",
   "scripts": {
     "test": "node index",

--- a/specifications/16-strategy-variants.json
+++ b/specifications/16-strategy-variants.json
@@ -217,6 +217,41 @@
             }
           }
         ]
+      },
+      {
+        "name": "Feature.strategy.variants.stickiness",
+        "description": "Strategy variants with stickiness inherited from the strategy",
+        "enabled": true,
+        "strategies": [
+          {
+            "name": "flexibleRollout",
+            "parameters": {
+              "rollout": "100",
+              "stickiness": "clientId",
+              "groupId": "a"
+            },
+            "variants": [
+              {
+                "name": "variantNameA",
+                "weight": 1,
+                "payload": {
+                  "type": "string",
+                  "value": "variantValueA"
+                }
+              },
+              {
+                "name": "variantNameB",
+                "weight": 1,
+                "payload": {
+                  "type": "string",
+                  "value": "variantValueB"
+                }
+              }
+            ],
+            "constraints": []
+          }
+        ],
+        "variants": []
       }
     ]
   },
@@ -348,6 +383,42 @@
         "payload": {
           "type": "number",
           "value": "1"
+        },
+        "enabled": true,
+        "feature_enabled": true
+      }
+    },
+    {
+      "description": "Feature.strategy.variants.stickiness should inherit stickiness from the strategy - first variant",
+      "context": {
+        "properties": {
+          "clientId": "1"
+        }
+      },
+      "toggleName": "Feature.strategy.variants.stickiness",
+      "expectedResult": {
+        "name": "variantNameA",
+        "payload": {
+          "type": "string",
+          "value": "variantValueA"
+        },
+        "enabled": true,
+        "feature_enabled": true
+      }
+    },
+    {
+      "description": "Feature.strategy.variants.stickiness should inherit stickiness from the strategy - second variant",
+      "context": {
+        "properties": {
+          "clientId": "2"
+        }
+      },
+      "toggleName": "Feature.strategy.variants.stickiness",
+      "expectedResult": {
+        "name": "variantNameB",
+        "payload": {
+          "type": "string",
+          "value": "variantValueB"
         },
         "enabled": true,
         "feature_enabled": true


### PR DESCRIPTION

## About the changes

Adding missing scenario where:
* stickiness is non default
* stickiness is available on strategy with variants
* stickiness is not available on variants themselves

This matches the data we get from edge.

What I don't want to specify and I deliberately omit is when variant on strategy and on strategy variant differ. This situation should not be possible. 

The values that I chose for test (clientId="1" and clientId="2") show the bug in the node SDK. 

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
