### PR TITLE
chore: combine a variant test with a segment contraint

### DIFF
--- a/specifications/15-global-constraints.json
+++ b/specifications/15-global-constraints.json
@@ -13,6 +13,44 @@
             "parameters": {},
             "segments": [1]
           }
+        ],
+        "variants": [
+            {
+                "name": "blue",
+                "weight": 25,
+                "stickiness": "customField",
+                "payload": {
+                    "type": "string",
+                    "value": "val1"
+                }
+            },
+            {
+                "name": "red",
+                "weight": 25,
+                "stickiness": "customField",
+                "payload": {
+                    "type": "string",
+                    "value": "val1"
+                }
+            },
+            {
+                "name": "green",
+                "weight": 25,
+                "stickiness": "customField",
+                "payload": {
+                    "type": "string",
+                    "value": "val1"
+                }
+            },
+            {
+                "name": "yellow",
+                "weight": 25,
+                "stickiness": "customField",
+                "payload": {
+                    "type": "string",
+                    "value": "val1"
+                }
+            }
         ]
       },
       {
@@ -196,6 +234,27 @@
       },
       "toggleName": "F9.withSeveralConstraintsAndSegments",
       "expectedResult": true
+    }
+  ],
+  "variantTests": [
+    {
+        "description": "F9.globalSegmentOn and customField=616 yields green",
+        "context": {
+          "properties": {
+            "version": "1.2.2",
+            "customField": "616"
+          }
+        },
+        "toggleName": "F9.globalSegmentOn",
+        "expectedResult": {
+            "name": "green",
+            "payload": {
+                "type": "string",
+                "value": "val1"
+            },
+            "enabled": true,
+            "feature_enabled": true
+        }
     }
   ]
 }


### PR DESCRIPTION
## About the changes
This test adds variants to an existing feature and expects them to work well in the presence of segments.

This covers the case reported here: https://github.com/Unleash/unleash-client-ruby/pull/194 (tested locally). 

Also, validated that the current unleash-client-node spec tests succeeds for this new scenario.