### PR TITLE
chore: add UTF-8 flag names test

### DIFF
--- a/specifications/18-utf8-flag-names.json
+++ b/specifications/18-utf8-flag-names.json
@@ -1,0 +1,42 @@
+{
+  "name": "18-utf8-flag-names",
+  "state": {
+    "version": 1,
+    "features": [
+      {
+        "name": "Feature.UTF-8.Hellø_Wørld",
+        "description": "Enabled basic UTF-8 toggle",
+        "enabled": true,
+        "strategies": [
+          {
+            "name": "default"
+          }
+        ]
+      },
+      {
+        "name": "Feature.UTF-8.😊_φriend_你好_🌍",
+        "description": "Enabled complex UTF-8 toggle",
+        "enabled": true,
+        "strategies": [
+          {
+            "name": "default"
+          }
+        ]
+      }
+    ]
+  },
+  "tests": [
+    {
+      "description": "Feature.UTF-8.Hellø_Wørld feature toggle should be enabled",
+      "context": {},
+      "toggleName": "Feature.UTF-8.Hellø_Wørld",
+      "expectedResult": true
+    },
+    {
+      "description": "Feature.UTF-8.😊_φriend_你好_🌍 feature toggle should be enabled",
+      "context": {},
+      "toggleName": "Feature.UTF-8.😊_φriend_你好_🌍",
+      "expectedResult": true
+    }
+  ]
+}

--- a/specifications/index.json
+++ b/specifications/index.json
@@ -15,5 +15,6 @@
   "14-constraint-semver-operators.json",
   "15-global-constraints.json",
   "16-strategy-variants.json",
-  "17-dependent-features.json"
+  "17-dependent-features.json",
+  "18-utf8-flag-names.json"
 ]


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3110/net-sdk-utf-8-scandinavian-character-issue

Adding a new test for flag names with valid UTF-8 characters.