### PR TITLE
chore: supply-chain hardening

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,6 +13,9 @@ on:
       - master
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
 
@@ -25,6 +28,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
     - name: Publish to npm
       uses: actions/setup-node@v4
       with:

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,5 @@
+# Supply-chain hardening: never run dependency lifecycle scripts
+# (preinstall/install/postinstall) during yarn install.
+# Note: publishing is unaffected — npm publish reads .npmrc, not this file,
+# so publish-time lifecycle scripts (prepack/prepare) still run.
+ignore-scripts true

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "minimumReleaseAge": "7 days"
 }


### PR DESCRIPTION
## About the changes

Supply-chain hardening, same pattern as Unleash/unleash-js-sdk#295 and Unleash/unleash-node-sdk#879 (prompted by the recent npm supply-chain attacks, e.g. keyv).

- Dependency install scripts disabled (`ignore-scripts true` in `.yarnrc`) — the main payload vector in these attacks
- Renovate: `minimumReleaseAge: "7 days"` cooldown (compromised versions are typically pulled within hours to days)
- `permissions: contents: read` on the CI workflow (release already had explicit permissions)
- `persist-credentials: false` on both checkouts — no workflow does git operations after checkout

## Verification

Clean `yarn install --frozen-lockfile` prints "Ignored scripts due to flag"; spec validation (`yarn test`) passes.
