### PR TITLE
chore: add semver spec for build metadata

### DIFF
--- a/specifications/14-constraint-semver-operators.json
+++ b/specifications/14-constraint-semver-operators.json
@@ -327,7 +327,7 @@
             "expectedResult": false
         },
         {
-            "description": "F8.semverGT should not be enabled for metadata",
+            "description": "F8.semverGT should be disabled if only metadata differs",
             "context": {
                 "properties": {
                     "version": "1.2.2+metadata"

--- a/specifications/14-constraint-semver-operators.json
+++ b/specifications/14-constraint-semver-operators.json
@@ -387,7 +387,7 @@
             "expectedResult": false
         },
         {
-            "description": "F8.semverLT should be disabled for metadata",
+            "description": "F8.semverLT should be disabled if only metadata differs",
             "context": {
                 "properties": {
                     "version": "1.2.2+metadata"

--- a/specifications/14-constraint-semver-operators.json
+++ b/specifications/14-constraint-semver-operators.json
@@ -200,6 +200,78 @@
                         ]
                     }
                 ]
+            },
+            {
+                "name": "F8.semverMetadataEQ",
+                "description": "semver",
+                "enabled": true,
+                "strategies": [
+                    {
+                        "name": "default",
+                        "parameters": {},
+                        "constraints": [
+                            {
+                                "contextName": "version",
+                                "operator": "SEMVER_EQ",
+                                "value": "1.2.2+metadata"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "F8.semverPreReleaseMetadataEQ",
+                "description": "semver",
+                "enabled": true,
+                "strategies": [
+                    {
+                        "name": "default",
+                        "parameters": {},
+                        "constraints": [
+                            {
+                                "contextName": "version",
+                                "operator": "SEMVER_EQ",
+                                "value": "1.2.2-alpha.1+metadata"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "F8.semverPreReleaseMetadataLT",
+                "description": "semver",
+                "enabled": true,
+                "strategies": [
+                    {
+                        "name": "default",
+                        "parameters": {},
+                        "constraints": [
+                            {
+                                "contextName": "version",
+                                "operator": "SEMVER_LT",
+                                "value": "1.2.2-alpha.1+metadata"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "F8.semverPreReleaseMetadataGT",
+                "description": "semver",
+                "enabled": true,
+                "strategies": [
+                    {
+                        "name": "default",
+                        "parameters": {},
+                        "constraints": [
+                            {
+                                "contextName": "version",
+                                "operator": "SEMVER_GT",
+                                "value": "1.2.2-alpha.1+metadata.1"
+                            }
+                        ]
+                    }
+                ]
             }
         ]
     },
@@ -209,6 +281,16 @@
             "context": {
                 "properties": {
                     "version": "1.2.2"
+                }
+            },
+            "toggleName":  "F8.semverEQ",
+            "expectedResult": true
+        },
+        {
+            "description": "F8.semverEQ should be enabled for metadata",
+            "context": {
+                "properties": {
+                    "version": "1.2.2+metadata"
                 }
             },
             "toggleName":  "F8.semverEQ",
@@ -243,6 +325,16 @@
             },
             "toggleName":  "F8.semverGT",
             "expectedResult": false
+        },
+        {
+            "description": "F8.semverGT should not be enabled for metadata",
+            "context": {
+                "properties": {
+                    "version": "1.2.2+metadata"
+                }
+            },
+            "toggleName":  "F8.semverGT",
+            "expectedResult": true
         },
         {
             "description": "F8.semverGTE should be enabled",
@@ -289,6 +381,16 @@
             "context": {
                 "properties": {
                     "version": "1.2.3"
+                }
+            },
+            "toggleName":  "F8.semverLT",
+            "expectedResult": false
+        },
+        {
+            "description": "F8.semverLT should be disabled for metadata",
+            "context": {
+                "properties": {
+                    "version": "1.2.2+metadata"
                 }
             },
             "toggleName":  "F8.semverLT",
@@ -452,6 +554,86 @@
                 }
             },
             "toggleName": "F8.invalidSemverWithLeadingV",
+            "expectedResult": false
+        },
+        {
+            "description": "F8.semverMetadataEQ should be enabled for no metadata",
+            "context": {
+                "properties": {
+                    "version": "1.2.2"
+                }
+            },
+            "toggleName":  "F8.semverMetadataEQ",
+            "expectedResult": true
+        },
+        {
+            "description": "F8.semverMetadataEQ should be enabled for metadata.1",
+            "context": {
+                "properties": {
+                    "version": "1.2.2+metadata.1"
+                }
+            },
+            "toggleName":  "F8.semverMetadataEQ",
+            "expectedResult": true
+        },
+        {
+            "description": "F8.semverMetadataEQ should be enabled for metadata",
+            "context": {
+                "properties": {
+                    "version": "1.2.2+metadata"
+                }
+            },
+            "toggleName":  "F8.semverMetadataEQ",
+            "expectedResult": true
+        },
+        {
+            "description": "F8.semverPreReleaseMetadataEQ should be enabled for no metadata",
+            "context": {
+                "properties": {
+                    "version": "1.2.2-alpha.1"
+                }
+            },
+            "toggleName":  "F8.semverPreReleaseMetadataEQ",
+            "expectedResult": true
+        },
+        {
+            "description": "F8.semverPreReleaseMetadataEQ should be enabled for metadata.1",
+            "context": {
+                "properties": {
+                    "version": "1.2.2-alpha.1+metadata.1"
+                }
+            },
+            "toggleName":  "F8.semverPreReleaseMetadataEQ",
+            "expectedResult": true
+        },
+        {
+            "description": "F8.semverPreReleaseMetadataEQ should be enabled for metadata",
+            "context": {
+                "properties": {
+                    "version": "1.2.2-alpha.1+metadata"
+                }
+            },
+            "toggleName":  "F8.semverPreReleaseMetadataEQ",
+            "expectedResult": true
+        },
+        {
+            "description": "F8.semverPreReleaseMetadataLT should not be enabled for no metadata",
+            "context": {
+                "properties": {
+                    "version": "1.2.2-alpha.1"
+                }
+            },
+            "toggleName":  "F8.semverPreReleaseMetadataLT",
+            "expectedResult": false
+        },
+        {
+            "description": "F8.semverPreReleaseMetadataGT should not be enabled for higher metadata",
+            "context": {
+                "properties": {
+                    "version": "1.2.2-alpha.1+metadata.2"
+                }
+            },
+            "toggleName":  "F8.semverPreReleaseMetadataGT",
             "expectedResult": false
         }
     ]

--- a/specifications/14-constraint-semver-operators.json
+++ b/specifications/14-constraint-semver-operators.json
@@ -577,7 +577,7 @@
             "expectedResult": true
         },
         {
-            "description": "F8.semverMetadataEQ should be enabled for metadata",
+            "description": "F8.semverMetadataEQ should be enabled if metadata matches",
             "context": {
                 "properties": {
                     "version": "1.2.2+metadata"

--- a/specifications/14-constraint-semver-operators.json
+++ b/specifications/14-constraint-semver-operators.json
@@ -597,7 +597,7 @@
             "expectedResult": true
         },
         {
-            "description": "F8.semverPreReleaseMetadataEQ should be enabled for metadata.1",
+            "description": "F8.semverPreReleaseMetadataEQ should be enabled if only metadata differs and contains a dot",
             "context": {
                 "properties": {
                     "version": "1.2.2-alpha.1+metadata.1"

--- a/specifications/14-constraint-semver-operators.json
+++ b/specifications/14-constraint-semver-operators.json
@@ -587,7 +587,7 @@
             "expectedResult": true
         },
         {
-            "description": "F8.semverPreReleaseMetadataEQ should be enabled for no metadata",
+            "description": "F8.semverPreReleaseMetadataEQ should be enabled if only metadata differs",
             "context": {
                 "properties": {
                     "version": "1.2.2-alpha.1"

--- a/specifications/14-constraint-semver-operators.json
+++ b/specifications/14-constraint-semver-operators.json
@@ -557,7 +557,7 @@
             "expectedResult": false
         },
         {
-            "description": "F8.semverMetadataEQ should be enabled for no metadata",
+            "description": "F8.semverMetadataEQ should be enabled if only metadata differs",
             "context": {
                 "properties": {
                     "version": "1.2.2"

--- a/specifications/14-constraint-semver-operators.json
+++ b/specifications/14-constraint-semver-operators.json
@@ -617,7 +617,7 @@
             "expectedResult": true
         },
         {
-            "description": "F8.semverPreReleaseMetadataLT should not be enabled for no metadata",
+            "description": "F8.semverPreReleaseMetadataLT should be disabled as both are equal after discarding metadata",
             "context": {
                 "properties": {
                     "version": "1.2.2-alpha.1"

--- a/specifications/14-constraint-semver-operators.json
+++ b/specifications/14-constraint-semver-operators.json
@@ -627,7 +627,7 @@
             "expectedResult": false
         },
         {
-            "description": "F8.semverPreReleaseMetadataGT should not be enabled for higher metadata",
+            "description": "F8.semverPreReleaseMetadataGT should be disabled for higher metadata cause metadata is ignored and both are equal",
             "context": {
                 "properties": {
                     "version": "1.2.2-alpha.1+metadata.2"

--- a/specifications/14-constraint-semver-operators.json
+++ b/specifications/14-constraint-semver-operators.json
@@ -567,7 +567,7 @@
             "expectedResult": true
         },
         {
-            "description": "F8.semverMetadataEQ should be enabled for metadata.1",
+            "description": "F8.semverMetadataEQ should be enabled if only metadata differs and contains a dot",
             "context": {
                 "properties": {
                     "version": "1.2.2+metadata.1"

--- a/specifications/14-constraint-semver-operators.json
+++ b/specifications/14-constraint-semver-operators.json
@@ -607,7 +607,7 @@
             "expectedResult": true
         },
         {
-            "description": "F8.semverPreReleaseMetadataEQ should be enabled for metadata",
+            "description": "F8.semverPreReleaseMetadataEQ should be enabled if only metadata differs",
             "context": {
                 "properties": {
                     "version": "1.2.2-alpha.1+metadata"


### PR DESCRIPTION
Adds a series of checks to ensure semver compatibility with regards to version build metadata.
for instance 1.2.2+metadata SEMVER_EQ 1.2.2
!1.2.2+metadata > 1.2.2
etc

The checks are not exhaustive, but from experience our SDKs should either fail all but one (+metadata == +metadata) of these or pass every single one.